### PR TITLE
Storage path 파일 이름 변경

### DIFF
--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -16,7 +16,7 @@ export function loadConfig(): Config {
 
 export function loadStorage({origin}: { origin: ReviewOrigins }): Storage {
     try {
-        const storagePath = `../${(origin == 'appstore') ? "storage.json" : 'playstore-storage.json'}`;
+        const storagePath = `../${(origin == 'appstore') ? "storage-appstore.json" : 'storage-playstore.json'}`;
         const storageData = fs.readFileSync(storagePath, "utf-8");
         return JSON.parse(storageData);
     } catch (error) {
@@ -27,7 +27,7 @@ export function loadStorage({origin}: { origin: ReviewOrigins }): Storage {
 
 export function saveStorage({storage, origin}: { storage: Storage, origin: ReviewOrigins }): void {
     try {
-        const storagePath = `../${(origin == 'appstore') ? "storage.json" : 'playstore-storage.json'}`;
+        const storagePath = `../${(origin == 'appstore') ? "storage-appstore.json" : 'storage-playstore.json'}`;
         fs.writeFileSync(storagePath, JSON.stringify(storage, null, 2));
     } catch (error) {
         console.error("Error:", error);


### PR DESCRIPTION
## 💡 배경 및 개요

Storage path 파일 이름 변경
다른 storage url로 지정되어있음

Resolves: X

## 📃 작업내용

- loadStorage, saveStorage에서 파일 이름 수정
- storage.json -> storage-appstore.json, playstore-storage.json -> storage-playstore.json
